### PR TITLE
Make organizations clickable (closes #47)

### DIFF
--- a/affiliation_shortener.yaml
+++ b/affiliation_shortener.yaml
@@ -3,124 +3,162 @@ affiliations:
 - full_name: Australian National University
   short_name: ANU
   country_code: AU
+  homepage: https://www.anu.edu.au/
 - full_name: Arizona State University
   short_name: ASU
   country_code: US
+  homepage: https://www.asu.edu/
 - full_name: Allen Institute for Brain Science
   short_name: Allen
   country_code: US
+  homepage: https://alleninstitute.org/
 - full_name: Allen Institute for Cell Science
   short_name: Allen
   country_code: US
+  homepage: https://alleninstitute.org/
 - full_name: Allen Institute for Cell Science, Seattle, WA, USA
   short_name: Allen
   country_code: US
+  homepage: https://alleninstitute.org/
 - full_name: Allen Institute for Neural Dynamics, Seattle, WA, USA
   short_name: Allen
   country_code: US
+  homepage: https://alleninstitute.org/
 - full_name: Axle Research and Technology, Rockville, USA
   short_name: Axle
   country_code: companys
+  homepage: https://axleinfo.com/
 - full_name: Bern
   short_name: Bern
   country_code: CH
+  homepage: https://www.unibe.ch/
 - full_name: BioVisionCenter of the University of Zurich
   short_name: BioVisionCenter
   country_code: CH
+  homepage: https://www.biovisioncenter.uzh.ch/en.html
 - full_name: Université de Bordeaux
   short_name: Bordeaux
   country_code: FR
+  homepage: https://www.u-bordeaux.fr/
 - full_name: Imaging Platform, Broad Institute of MIT and Harvard, Cambridge, MA,
     USA
   short_name: Broad
   country_code: US
+  homepage: https://www.broadinstitute.org/
 - full_name: Laboratoire d'Optique et Biosciences, Ecole Polytechnique, CNRS
   short_name: CNRS
   country_code: FR
+  homepage: https://www.cnrs.fr/en
 - full_name: CNRS
   short_name: CNRS
   country_code: FR
+  homepage: https://www.cnrs.fr/en
 - full_name: Chan Zuckerberg Biohub, San Francisco, CA, USA
   short_name: CZ Biohub
   country_code: US
+  homepage: https://www.czbiohub.org/sf/
 - full_name: Caltech
   short_name: Caltech
   country_code: US
+  homepage: https://www.caltech.edu/
 - full_name: University of Cambridge
   short_name: Cambridge
   country_code: UK
+  homepage: https://www.cam.ac.uk/
 - full_name: Crick
   short_name: Crick
   country_code: UK
+  homepage: https://www.crick.ac.uk/
 - full_name: Dartmouth College, Hanover, NH, USA
   short_name: Dartmouth
   country_code: US
+  homepage: https://home.dartmouth.edu/
 - full_name: University of Dundee
   short_name: Dundee
   country_code: UK
+  homepage: https://www.dundee.ac.uk/
 - full_name: Divisions of Molecular Cell and Developmental Biology, and Computational
     Biology, University of Dundee, Dundee, Scotland, UK
   short_name: Dundee
   country_code: UK
+  homepage: https://www.dundee.ac.uk/
 - full_name: Dundee
   short_name: Dundee
   country_code: UK
+  homepage: https://www.dundee.ac.uk/
 - full_name: European Molecular Biology Laboratory, European Bioinformatics Institute,
     EMBL-EBI, Cambridge, UK
   short_name: EBI
   country_code: UK
+  homepage: https://www.ebi.ac.uk/
 - full_name: EBI
   short_name: EBI
   country_code: UK
+  homepage: https://www.ebi.ac.uk/
 - full_name: EMBL, Heidelberg, Germany
   short_name: EMBL
   country_code: DE
+  homepage: https://www.embl.org/
 - full_name: EMBL
   short_name: EMBL
   country_code: DE
+  homepage: https://www.embl.org/
 - full_name: Genome Biology Unit, European Molecular Biology Laboratory (EMBL), Heidelberg,
     Germany
   short_name: EMBL
   country_code: DE
+  homepage: https://www.embl.org/
 - full_name: Data Science Centre, European Molecular Biology Laboratory (EMBL), Heidelberg,
     Germany
   short_name: EMBL
   country_code: DE
+  homepage: https://www.embl.org/
 - full_name: EPFL
   short_name: EPFL
   country_code: CH
+  homepage: https://www.epfl.ch/
 - full_name: Department of Biosystems Science and Engineering, ETH Zürich, Zürich,
     Switzerland
   short_name: ETH
   country_code: CH
+  homepage: https://ethz.ch/en.html
 - full_name: ETH
   short_name: ETH
   country_code: CH
+  homepage: https://ethz.ch/en.html
 - full_name: University of Edinburgh, Edinburgh, UK
   short_name: Edinburgh
   country_code: UK
+  homepage: https://www.ed.ac.uk/
 - full_name: Euro-BioImaging Bio-Hub, EMBL, Heidelberg, Germany
   short_name: Euro-BioImaging
   country_code: DE
+  homepage: https://www.eurobioimaging.eu/
 - full_name: Friedrich Miescher Institute for Biomedical Imaging, Basel, Switzerland
   short_name: FMI
   country_code: CH
+  homepage: https://www.fmi.ch/
 - full_name: FMI
   short_name: FMI
   country_code: CH
+  homepage: https://www.fmi.ch/
 - full_name: Fideus Labs, Research Triangle Park, NC, USA
   short_name: Fideus
   country_code: company
+  homepage: https://fideus.io/
 - full_name: France BioImaging
   short_name: France BioImaging
   country_code: FR
+  homepage: https://france-bioimaging.org/
 - full_name: Universität Freiburg (CH)
   short_name: Freiburg (CH)
   country_code: CH
+  homepage: https://www.unifr.ch/
 - full_name: German BioImaging-Gesellschaft für Mikroskopie und Bildanalyse e.V.,
     Constance, Germany
   short_name: German BioImaging
   country_code: DE
+  homepage: https://gerbi-gmb.de/
   order_override:
   - Josh Moore
   - Johannes Soltwedel
@@ -132,179 +170,235 @@ affiliations:
 - full_name: Glencoe Software Inc., Seattle, WA, USA
   short_name: Glencoe
   country_code: company
+  homepage: https://www.glencoesoftware.com/
 - full_name: Google Research, Mountain View, CA, USA
   short_name: Google
   country_code: company
+  homepage: https://research.google/
 - full_name: Georg-August-Universität Göttingen, Göttingen, Germany
   short_name: Göttingen
   country_code: DE
+  homepage: https://www.uni-goettingen.de/
 - full_name: Howard Hughes Medical Institute
   short_name: HHMI
   country_code: US
+  homepage: https://www.hhmi.org/
 - full_name: Heinrich Heine University Düsseldorf
   short_name: HHU Düsseldorf
   country_code: DE
+  homepage: https://www.hhu.de/
 - full_name: Harvard Medical School
   short_name: HMS
   country_code: US
+  homepage: https://hms.harvard.edu/
 - full_name: Harvard Medical School, Boston, MA, USA
   short_name: HMS
   country_code: US
+  homepage: https://hms.harvard.edu/
 - full_name: Institute of Computational Biology, Helmholtz Zentrum München, Neuherberg,
     Germany
   short_name: Helmholtz München
   country_code: DE
+  homepage: https://www.helmholtz-munich.de/
 - full_name: Paris Brain Institute
   short_name: ICM
   country_code: FR
+  homepage: https://parisbraininstitute.org/
 - full_name: IST, Austria
   short_name: IST
   country_code: AT
+  homepage: https://ista.ac.at/
 - full_name: Image Cooperative
   short_name: Image Coop
   country_code: company
+  homepage: https://image.coop/
 - full_name: The Jackson Laboratory (JAX)
   short_name: JAX
   country_code: US
+  homepage: https://www.jax.org/
 - full_name: JAX
   short_name: JAX
   country_code: US
+  homepage: https://www.jax.org/
 - full_name: Johns Hopkins University
   short_name: JHU
   country_code: US
+  homepage: https://www.jhu.edu/
 - full_name: Howard Hughes Medical Institute, Janelia Research Campus
   short_name: Janelia
   country_code: US
+  homepage: https://www.janelia.org/
 - full_name: Janelia Research Campus, Howard Hughes Medical Institute, Ashburn, VA,
     USA
   short_name: Janelia
   country_code: US
+  homepage: https://www.janelia.org/
 - full_name: Janelia
   short_name: Janelia
   country_code: US
+  homepage: https://www.janelia.org/
 - full_name: Forschungszentrum Jülich GmbH
   short_name: Jülich
   country_code: DE
+  homepage: https://www.fz-juelich.de/
 - full_name: Kitware
   short_name: Kitware
   country_code: company
+  homepage: https://www.kitware.com/
 - full_name: Leibniz Institute of Photonic Technology (Leibniz IPHT), Jena, Germany
   short_name: Leibniz IPHT
   country_code: DE
+  homepage: https://www.leibniz-ipht.de/
 - full_name: Department of Experimental Medical Science & Lund Bioimaging Centre,
     Lund University, Lund, Sweden
   short_name: Lund University
   country_code: SE
+  homepage: https://www.lunduniversity.lu.se/
 - full_name: Max-Delbrück-Centrum für Molekulare Medizin
   short_name: MDC
   country_code: DE
+  homepage: https://www.mdc-berlin.de/
 - full_name: Massachusetts Institute of Technology, Cambridge, MA, USA
   short_name: MIT
   country_code: US
+  homepage: https://www.mit.edu/
 - full_name: Masaryk University Brno
   short_name: MUNI
   country_code: CZ
+  homepage: https://www.muni.cz/
 - full_name: University of Wisconsin, Madison
   short_name: Madison
   country_code: US
+  homepage: https://www.wisc.edu/
 - full_name: Many more
   short_name: Many more
   country_code: plus
 - full_name: Miltenyi Biotec
   short_name: Miltenyi Biotec
   country_code: company
+  homepage: https://www.miltenyibiotec.com/
 - full_name: Monash University
   short_name: Monash
   country_code: AU
+  homepage: https://www.monash.edu/
 - full_name: University of Münster
   short_name: Münster
   country_code: DE
+  homepage: https://www.uni-muenster.de/
 - full_name: National Cancer Institute
   short_name: NCI
   country_code: US
+  homepage: https://www.cancer.gov/
 - full_name: Information Technology Branch, National Center for Advancing Translational
     Science, National Institutes of Health, Bethesda, USA
   short_name: NIH
   country_code: US
+  homepage: https://www.nih.gov/
 - full_name: NIH
   short_name: NIH
   country_code: US
+  homepage: https://www.nih.gov/
 - full_name: Biosciences Institute, Newcastle University, Newcastle upon Tyne, UK
   short_name: Newcastle University Biosciences
   country_code: UK
+  homepage: https://www.ncl.ac.uk/
 - full_name: Institut Pasteur, Paris, France
   short_name: Pasteur
   country_code: FR
+  homepage: https://www.pasteur.fr/en
 - full_name: Pasteur
   short_name: Pasteur
   country_code: FR
+  homepage: https://www.pasteur.fr/en
 - full_name: University of Pittsburgh, Pittsburgh, PA, USA
   short_name: Pittsburgh
   country_code: US
+  homepage: https://www.pitt.edu/
 - full_name: RIKEN Center for Biosystems Dynamics Research, Kobe, Japan
   short_name: RIKEN
   country_code: JP
+  homepage: https://www.bdr.riken.jp/en/
 - full_name: Roche
   short_name: Roche
   country_code: company
+  homepage: https://www.roche.com/
 - full_name: Wellcome Sanger Institute, Hinxton, UK
   short_name: Sanger
   country_code: UK
+  homepage: https://www.sanger.ac.uk/
 - full_name: Sanger
   short_name: Sanger
   country_code: UK
+  homepage: https://www.sanger.ac.uk/
 - full_name: Science for Life Laboratory, KTH Royal Institute of Technology, Stockholm,
     Sweden
   short_name: SciLifeLab
   country_code: SE
+  homepage: https://www.scilifelab.se/
 - full_name: Science for Life Laboratory, Uppsala University, Uppsala, Sweden
   short_name: SciLifeLab
   country_code: SE
+  homepage: https://www.scilifelab.se/
 - full_name: SciLifeLab
   short_name: SciLifeLab
   country_code: SE
+  homepage: https://www.scilifelab.se/
 - full_name: TU Dresden
   short_name: TU Dresden
   country_code: DE
+  homepage: https://tu-dresden.de/
 - full_name: Human Technopole, Milan, Italy
   short_name: Technopole
   country_code: IT
+  homepage: https://humantechnopole.it/en/
 - full_name: University of Tübingen
   short_name: Tübingen
   country_code: DE
+  homepage: https://uni-tuebingen.de/
 - full_name: UCL
   short_name: UCL
   country_code: UK
+  homepage: https://www.ucl.ac.uk/
 - full_name: University College London
   short_name: UCL
   country_code: UK
+  homepage: https://www.ucl.ac.uk/
 - full_name: UMN
   short_name: UMN
   country_code: US
+  homepage: https://umn.edu/
 - full_name: UMass Chan Medical School
   short_name: UMass
   country_code: US
+  homepage: https://www.umassmed.edu/
 - full_name: VIB
   short_name: VIB
   country_code: BE
+  homepage: https://vib.be/
 - full_name: VSB - Technical University of Ostrava
   short_name: VSB - TU Ostrava
   country_code: CZ
+  homepage: https://www.vsb.cz/en
 - full_name: Yikes
   short_name: Yikes
   country_code: company
 - full_name: Zeiss
   short_name: Zeiss
   country_code: company
+  homepage: https://www.zeiss.com/
 - full_name: University of Zürich, Zürich, Switzerland
   short_name: Zürich
   country_code: CH
+  homepage: https://www.uzh.ch/en.html
 - full_name: Zürich
   short_name: Zürich
   country_code: CH
+  homepage: https://www.uzh.ch/en.html
 - full_name: eXact lab
   short_name: eXact lab
   country_code: company
+  homepage: https://www.exact-lab.it/
 - full_name: scalable minds GmbH, Potsdam, Germany
   short_name: scalable minds
   country_code: company
+  homepage: https://scalableminds.com/

--- a/affiliation_shortener.yaml
+++ b/affiliation_shortener.yaml
@@ -31,6 +31,7 @@ affiliations:
 - full_name: Institute of Cell Biology University of Bern
   short_name: Bern
   country_code: CH
+  homepage: https://www.unibe.ch/
 - full_name: Bern
   short_name: Bern
   country_code: CH
@@ -82,6 +83,7 @@ affiliations:
 - full_name: University of Debrecen
   short_name: Debrecen
   country_code: HU
+  homepage: https://www.unideb.hu/en
 - full_name: University of Dundee
   short_name: Dundee
   country_code: UK
@@ -216,6 +218,7 @@ affiliations:
 - full_name: Imaging Core Facility Biozentrum Basel
   short_name: IMCF
   country_code: CH
+  homepage: https://www.biozentrum.unibas.ch/facilities
 - full_name: IST, Austria
   short_name: IST
   country_code: AT
@@ -288,6 +291,7 @@ affiliations:
 - full_name: Athinoula A. Martinos Center for Biomedical Imaging
   short_name: Martinos
   country_code: US
+  homepage: https://www.martinos.org/
 - full_name: Miltenyi Biotec
   short_name: Miltenyi Biotec
   country_code: company
@@ -328,6 +332,7 @@ affiliations:
 - full_name: University of Pennsylvania
   short_name: Penn
   country_code: US
+  homepage: https://www.upenn.edu/
 - full_name: University of Pittsburgh, Pittsburgh, PA, USA
   short_name: Pittsburgh
   country_code: US
@@ -339,6 +344,7 @@ affiliations:
 - full_name: Robarts Research Institute, University of Western Ontario
   short_name: Robarts
   country_code: CA
+  homepage: https://www.robarts.ca/
 - full_name: Roche
   short_name: Roche
   country_code: company
@@ -367,6 +373,7 @@ affiliations:
 - full_name: Université de Strasbourg
   short_name: Strasbourg
   country_code: FR
+  homepage: https://www.unistra.fr/
 - full_name: TU Dresden
   short_name: TU Dresden
   country_code: DE
@@ -390,6 +397,7 @@ affiliations:
 - full_name: UConn Health
   short_name: UConn
   country_code: US
+  homepage: https://health.uconn.edu/
 - full_name: UMN
   short_name: UMN
   country_code: US
@@ -401,12 +409,15 @@ affiliations:
 - full_name: Universidad Nacional Autónoma de México
   short_name: UNAM
   country_code: MX
+  homepage: https://www.unam.mx/
 - full_name: University of Texas Southwestern Medical Center
   short_name: UTSW
   country_code: US
+  homepage: https://www.utsouthwestern.edu/
 - full_name: University of Washington, Seattle, WA, USA
   short_name: UW
   country_code: US
+  homepage: https://www.washington.edu/
 - full_name: VIB
   short_name: VIB
   country_code: BE
@@ -437,6 +448,7 @@ affiliations:
 - full_name: i3S - Institute for Research and Innovation in Health, Porto, Portugal
   short_name: i3S
   country_code: PT
+  homepage: https://www.i3s.up.pt/
 - full_name: scalable minds GmbH, Potsdam, Germany
   short_name: scalable minds
   country_code: company

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -12,35 +11,29 @@
         :root {
             color-scheme: dark light;
         }
-
         body {
             margin: 0;
             padding: 2rem;
             font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-
             --bg-color: #111;
             --text-color: #f5f5f5;
             --muted-color: #ccc;
             --soft-muted: #888;
-
             background-color: var(--bg-color);
             color: var(--text-color);
             transition: background-color 0.25s ease, color 0.25s ease;
         }
-
         body.light {
             --bg-color: #f5f5f5;
             --text-color: #111;
             --muted-color: #555;
             --soft-muted: #777;
         }
-
         h1 {
             margin: 0 0 1rem;
             font-weight: 600;
             font-size: 1.5rem;
         }
-
         h2 {
             margin-top: 2rem;
             margin-bottom: 0.75rem;
@@ -50,32 +43,30 @@
             letter-spacing: 0.08em;
             color: var(--muted-color);
         }
-
         #paper-people {
             font-size: 0.95rem;
             line-height: 1.6;
             white-space: pre-wrap;
         }
-
         .country {
             font-weight: 700;
             margin-right: 0.17rem;
         }
-
         .aff {
             font-weight: 600;
             margin: 0 0.17rem;
+            cursor: pointer;
         }
-
+        .aff:hover {
+            text-decoration: underline;
+        }
         .people-list {
             margin-left: 0.15rem;
         }
-
         .person-name {
             position: relative;
             cursor: pointer;
         }
-
         .person-hint {
             display: none;
             position: absolute;
@@ -90,11 +81,9 @@
             white-space: nowrap;
             pointer-events: none;
         }
-
         .person-name:hover .person-hint {
             display: block;
         }
-
         .person-overlay {
             position: fixed;
             inset: 0;
@@ -102,9 +91,7 @@
             z-index: 999;
             display: none;
         }
-
         .person-overlay.visible { display: block; }
-
         .person-modal {
             position: fixed;
             top: 50%;
@@ -117,16 +104,16 @@
             z-index: 1000;
             display: none;
             min-width: 180px;
+            max-width: min(90vw, 360px);
+            max-height: 80vh;
+            overflow-y: auto;
         }
-
         .person-modal.visible { display: block; }
-
         .person-modal-name {
             font-weight: 600;
             margin-bottom: 0.75rem;
             text-align: center;
         }
-
         .person-modal-row {
             display: flex;
             align-items: center;
@@ -134,37 +121,73 @@
             margin: 0.4rem 0;
             font-size: 0.85rem;
         }
-
         .person-modal-row img {
             width: 14px;
             height: 14px;
         }
-
         .person-modal-row a {
             color: var(--text-color);
             text-decoration: none;
             font-family: ui-monospace, monospace;
             font-size: 0.8rem;
         }
-
         .person-modal-row a:hover { text-decoration: underline; }
-
         .person-modal-row .gh-icon { filter: invert(1); }
         body.light .person-modal-row .gh-icon { filter: invert(0); }
-
         .person-modal-empty {
             color: var(--muted-color);
             font-size: 0.85rem;
             font-style: italic;
             text-align: center;
         }
-
+        /* Affiliation modal specific */
+        .aff-modal-homepage {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.4rem;
+            margin-bottom: 0.75rem;
+            padding-bottom: 0.75rem;
+            border-bottom: 1px solid var(--soft-muted);
+            font-size: 0.85rem;
+        }
+        .aff-modal-homepage a {
+            color: var(--text-color);
+            text-decoration: none;
+            font-family: ui-monospace, monospace;
+            font-size: 0.8rem;
+            word-break: break-all;
+        }
+        .aff-modal-homepage a:hover { text-decoration: underline; }
+        .aff-modal-person {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin: 0.45rem 0;
+            font-size: 0.9rem;
+        }
+        .aff-modal-person .aff-person-name {
+            flex: 1;
+        }
+        .aff-modal-person .aff-person-icons {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+        .aff-modal-person .aff-person-icons a {
+            display: inline-flex;
+        }
+        .aff-modal-person .aff-person-icons img {
+            width: 14px;
+            height: 14px;
+        }
+        .aff-modal-person .aff-person-icons .gh-icon { filter: invert(1); }
+        body.light .aff-modal-person .aff-person-icons .gh-icon { filter: invert(0); }
         .sep {
             margin: 0 0.5rem;
             opacity: 0.7;
             color: var(--soft-muted);
         }
-
         #others {
             display: flex;
             flex-wrap: wrap;
@@ -172,12 +195,10 @@
             font-size: 0.8rem;
             opacity: 0.9;
         }
-
         .error {
             color: #ff6b6b;
             margin-top: 1rem;
         }
-
         .top-bar {
             display: flex;
             align-items: center;
@@ -185,7 +206,6 @@
             gap: 1rem;
             margin-bottom: 1.5rem;
         }
-
         .theme-toggle {
             border: 1px solid var(--soft-muted);
             background: transparent;
@@ -195,11 +215,9 @@
             font-size: 0.8rem;
             cursor: pointer;
         }
-
         .theme-toggle:hover {
             border-color: var(--muted-color);
         }
-
         .site-footer {
             margin-top: 3rem;
             padding-top: 1.5rem;
@@ -207,54 +225,41 @@
             font-size: 0.85rem;
             color: var(--muted-color);
         }
-
         .site-footer a {
             color: inherit;
             text-decoration: underline;
         }
     </style>
-
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
 </head>
-
 <body>
     <div class="top-bar">
         <h1>OME-Zarr Contributors</h1>
         <div>        <button id="theme-toggle" class="theme-toggle" type="button">🔆/🌙</button>
         <button onclick="window.location.href='./map'"  class="theme-toggle"  type="button">📍🗺️</button>
     </div>
-
     </div>
-
     <!-- <h2>Contributors</h2> -->
     <div id="paper-people"></div>
-
     <h2 id="additional-heading">Additional contributors</h2>
     <div id="others" aria-label="additional contributors list"></div>
-
     <div id="error" class="error"></div>
-
     <div class="person-overlay" id="person-overlay"></div>
     <div class="person-modal" id="person-modal">
         <div class="person-modal-name" id="modal-name"></div>
         <div id="modal-content"></div>
     </div>
-
-
     <footer class="site-footer">
         Something to change? <a href="https://github.com/German-BioImaging/ome-zarr-acknowledgments">let us know</a>
     </footer>
-
     <script>
         // Icon URLs for profile links
         const ORCID_ICON = "https://orcid.org/assets/vectors/orcid.logo.icon.svg";
         const GITHUB_ICON = "./icons/invertocat.svg";
-
         // 🌈 rainbow color mapping, with a darker tone in light mode
         function getRainbowColor(index, total, isLightMode) {
             const denom = Math.max(1, total - 1);
             const hue = Math.round((index / denom) * 300);
-
             // use slightly darker, lower-saturation colors in light mode for better contrast
             if (isLightMode) {
                 return `hsl(${hue}, 65%, 45%)`; // softer tones
@@ -262,11 +267,9 @@
                 return `hsl(${hue}, 85%, 65%)`; // vivid tones
             }
         }
-
         function initThemeToggle() {
             const btn = document.getElementById('theme-toggle');
             const body = document.body;
-
             // Check localStorage first, then system preference
             const saved = localStorage.getItem('theme-mode');
             if (saved === 'light') {
@@ -277,12 +280,10 @@
                     body.classList.add('light');
                 }
             }
-
             function updateLabel() {
                 const light = body.classList.contains('light');
                 btn.textContent = light ? '🔆' : '🌙';
             }
-
             updateLabel();
             btn.addEventListener('click', () => {
                 body.classList.toggle('light');
@@ -293,31 +294,27 @@
                 renderColors();
             });
         }
-
         // We'll store colors and re-render them if the theme changes
         const GAP = '\u00a0'.repeat(1);
         let currentBlocks = [];
         let peopleMap = new Map();
-
+        let affInfoMap = new Map(); // full_name -> affiliation config (incl. homepage)
         const overlay = document.getElementById('person-overlay');
         const modal = document.getElementById('person-modal');
         const modalName = document.getElementById('modal-name');
         const modalContent = document.getElementById('modal-content');
-
         function closeModal() {
             overlay.classList.remove('visible');
             modal.classList.remove('visible');
         }
-
         function getOrcidId(orcid) {
             const m = orcid?.match(/(\d{4}-\d{4}-\d{4}-\d{3}[\dX])/);
             return m ? m[1] : orcid;
         }
-
         function openModal(name) {
             const p = peopleMap.get(name);
             modalName.textContent = name;
-            
+
             if (!p?.orcid && !p?.github) {
                 modalContent.innerHTML = '<div class="person-modal-empty">No public profiles linked</div>';
             } else {
@@ -331,28 +328,62 @@
                 }
                 modalContent.innerHTML = html;
             }
-            
+
             overlay.classList.add('visible');
             modal.classList.add('visible');
         }
+        function escapeHtml(str) {
+            return String(str).replace(/[&<>"']/g, c => ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+            }[c]));
+        }
+        function openAffModal(block) {
+            const cfg = affInfoMap.get(block.full_name) || {};
+            const homepage = cfg.homepage;
+            modalName.textContent = block.aff_short;
 
+            let html = '';
+            if (homepage) {
+                const safeHref = escapeHtml(homepage);
+                let display = homepage.replace(/^https?:\/\//, '').replace(/\/$/, '');
+                html += `<div class="aff-modal-homepage">🌐<a href="${safeHref}" target="_blank">${escapeHtml(display)}</a></div>`;
+            }
+
+            if (!block.people.length) {
+                html += '<div class="person-modal-empty">No listed contributors</div>';
+            } else {
+                block.people.forEach(name => {
+                    const p = peopleMap.get(name) || {};
+                    let icons = '';
+                    if (p.orcid) {
+                        const id = getOrcidId(p.orcid);
+                        icons += `<a href="https://orcid.org/${escapeHtml(id)}" target="_blank" title="ORCID"><img src="${ORCID_ICON}" alt="ORCID"></a>`;
+                    }
+                    if (p.github) {
+                        icons += `<a href="https://github.com/${escapeHtml(p.github)}" target="_blank" title="GitHub"><img src="${GITHUB_ICON}" alt="GitHub" class="gh-icon"></a>`;
+                    }
+                    html += `<div class="aff-modal-person"><span class="aff-person-name">${escapeHtml(name)}</span><span class="aff-person-icons">${icons}</span></div>`;
+                });
+            }
+
+            modalContent.innerHTML = html;
+            overlay.classList.add('visible');
+            modal.classList.add('visible');
+        }
         function createPersonElement(name) {
             const p = peopleMap.get(name);
             const span = document.createElement('span');
             span.className = 'person-name';
             span.textContent = name;
-
             if (p?.orcid || p?.github) {
                 const hint = document.createElement('span');
                 hint.className = 'person-hint';
                 hint.textContent = [p.orcid && 'ORCID', p.github && 'GitHub'].filter(Boolean).join(' · ');
                 span.appendChild(hint);
             }
-
             span.onclick = (e) => { e.stopPropagation(); openModal(name); };
             return span;
         }
-
         function renderColors() {
             const paperContainer = document.getElementById('paper-people');
             const isLightMode = document.body.classList.contains('light');
@@ -362,36 +393,29 @@
                 el.style.color = getRainbowColor(i, totalAffBlocks, isLightMode);
             });
         }
-
         async function loadData() {
             const errorEl = document.getElementById('error');
-
             try {
                 const [peopleResp, affResp] = await Promise.all([
                     fetch('people.yaml'),
                     fetch('affiliation_shortener.yaml'),
                 ]);
-
                 if (!peopleResp.ok) throw new Error('Cannot load people.yaml: ' + peopleResp.statusText);
                 if (!affResp.ok) throw new Error('Cannot load affiliation_shortener.yaml: ' + affResp.statusText);
-
                 const [peopleText, affText] = await Promise.all([peopleResp.text(), affResp.text()]);
                 const peopleData = jsyaml.load(peopleText);
                 const affData = jsyaml.load(affText);
-
                 const people = peopleData.people || [];
                 const affiliations = affData.affiliations || [];
-
                 // Build a map of person name -> person data for icon rendering
                 people.forEach(p => {
                     peopleMap.set(p.name, { orcid: p.orcid, github: p.github });
                 });
-
                 const affMap = new Map();
                 affiliations.forEach(a => {
                     if (a.full_name) affMap.set(a.full_name, a);
                 });
-
+                affInfoMap = affMap; // expose full config (incl. homepage) to modal
                 function getAffEntry(full) {
                     const entry = affMap.get(full);
                     if (!entry) {
@@ -400,12 +424,10 @@
                     }
                     return entry;
                 }
-
                 // People with at least one affiliation are grouped by affiliation
                 const hasAffiliation = person => Array.isArray(person.affiliations) && person.affiliations.length > 0;
                 const affiliatedPeople = people.filter(hasAffiliation);
                 const unaffiliatedPeople = people.filter(p => !hasAffiliation(p));
-
                 // build affiliation blocks
                 const blocksMap = new Map();
                 affiliatedPeople.forEach(person => {
@@ -422,27 +444,22 @@
                         if (!block.people.includes(person.name)) block.people.push(person.name);
                     });
                 });
-
                 const blocks = Array.from(blocksMap.values());
                 currentBlocks = blocks; // store for re-rendering colors later
-
                 // apply order_override
                 blocks.forEach(block => {
                     const affConfig = affMap.get(block.full_name);
                     if (!affConfig || !Array.isArray(affConfig.order_override)) return;
                     const override = affConfig.order_override;
                     const peopleSet = new Set(block.people);
-
                     override.forEach(name => {
                         if (!peopleSet.has(name))
                             console.warn('%c⚠️ order_override name not in people list:', 'color: magenta', `"${name}" → ${block.aff_short}`);
                     });
-
                     block.people.forEach(name => {
                         if (!override.includes(name))
                             console.warn('%c⚠️ Person missing from order_override:', 'color: cyan', `"${name}" → ${block.aff_short}`);
                     });
-
                     const ordered = [];
                     override.forEach(name => {
                         if (peopleSet.has(name)) ordered.push(name);
@@ -452,7 +469,6 @@
                     });
                     block.people = ordered;
                 });
-
                 // group by country
                 const countryGroups = new Map();
                 blocks.forEach(b => {
@@ -460,19 +476,16 @@
                     if (!countryGroups.has(c)) countryGroups.set(c, []);
                     countryGroups.get(c).push(b);
                 });
-
                 const countryCodes = Array.from(countryGroups.keys()).sort();
                 countryCodes.forEach(c => {
                     countryGroups.get(c).sort((a, b) => a.aff_short.localeCompare(b.aff_short));
                 });
-
                 const paperContainer = document.getElementById('paper-people');
                 const isLightMode = document.body.classList.contains('light');
                 const totalAffBlocks = blocks.length;
                 let affIndex = 0;
                 const computedStyles = getComputedStyle(document.body);
                 const softMutedColor = (computedStyles.getPropertyValue('--soft-muted') || '').trim() || '#888';
-
                 countryCodes.forEach((country, ci) => {
                     const countryBlocks = countryGroups.get(country);
                     if (!countryBlocks.length) return;
@@ -490,19 +503,19 @@
                     countrySpan.style.fontWeight = '700';
                     paperContainer.appendChild(countrySpan);
                     paperContainer.appendChild(document.createTextNode(GAP));
-
                     countryBlocks.forEach(block => {
                         const affSpan = document.createElement('span');
                         affSpan.className = 'aff';
                         affSpan.textContent = block.aff_short;
                         affSpan.style.color = getRainbowColor(affIndex, totalAffBlocks, isLightMode);
                         affIndex++;
+                        affSpan.title = block.full_name;
+                        affSpan.onclick = (e) => { e.stopPropagation(); openAffModal(block); };
                         paperContainer.appendChild(affSpan);
-
                         const peopleSpan = document.createElement('span');
                         peopleSpan.className = 'people-list';
                         paperContainer.appendChild(document.createTextNode(GAP));
-                        
+
                         // Render each person with potential icon popup
                         block.people.forEach((name, idx) => {
                             const personEl = createPersonElement(name);
@@ -511,12 +524,11 @@
                                 peopleSpan.appendChild(document.createTextNode(', '));
                             }
                         });
-                        
+
                         paperContainer.appendChild(peopleSpan);
                         paperContainer.appendChild(document.createTextNode(GAP));
                     });
                 });
-
                 // Additional contributors (no listed affiliation); keep visual wrap while preserving spaces on copy
                 const othersHeading = document.getElementById('additional-heading');
                 const othersContainer = document.getElementById('others');
@@ -534,14 +546,12 @@
                         }
                     });
                 }
-
                 console.info('%c✅ Load complete', 'color: lightgreen', affiliatedPeople.length, 'affiliated contributors,', unaffiliatedPeople.length, 'unaffiliated.');
             } catch (err) {
                 console.error(err);
                 errorEl.textContent = err.message;
             }
         }
-
         document.addEventListener('DOMContentLoaded', () => {
             initThemeToggle();
             loadData();
@@ -550,5 +560,4 @@
         });
     </script>
 </body>
-
 </html>


### PR DESCRIPTION

adds a simple "homepage" key to affiliations, now clicking on them looks like: 


<img width="469" height="397" alt="grafik" src="https://github.com/user-attachments/assets/e5847432-2223-4dd3-81bd-998cef9af155" />

<img width="469" height="397" alt="grafik" src="https://github.com/user-attachments/assets/8bb82c07-45c5-4bad-9b49-d93d5540f64b" />


- **feat: add support for org view**
- **add curated homepages for the orgs**

Closes #47 
